### PR TITLE
chore: sticky cache namings

### DIFF
--- a/GrowthBookTests/StickyBucketingTests.swift
+++ b/GrowthBookTests/StickyBucketingTests.swift
@@ -77,7 +77,7 @@ class StickyBucketingFeatureTests: XCTestCase {
         let cacheKeyPrefix: String = "_"
         let attributeName: String = "id"
         let attributeValue: String = "some-id"
-        let hash = "\(attributeName)||\(attributeValue)"
+        let hash = "\(attributeName)||\(attributeValue)".sha256HashString
         let cacheKey: String = "\(cacheKeyPrefix)\(hash)"
 
         let doc: StickyAssignmentsDocument = .init(attributeName: attributeName, attributeValue: attributeValue, assignments: assignments)
@@ -100,7 +100,7 @@ class StickyBucketingFeatureTests: XCTestCase {
         let cacheKeyPrefix: String = "_"
         let attributeName: String = "id"
         let attributeValue: String = "some-id"
-        let hash = "\(attributeName)||\(attributeValue)"
+        let hash = "\(attributeName)||\(attributeValue)".sha256HashString
         let cacheKey: String = "\(cacheKeyPrefix)\(hash)"
 
         let initialService: StickyBucketService = .init(prefix: cacheKeyPrefix, cache: cacheMock)

--- a/Sources/CommonMain/Caching/CachingManager.swift
+++ b/Sources/CommonMain/Caching/CachingManager.swift
@@ -15,13 +15,7 @@ public class CachingManager: CachingLayer {
     public static let shared = CachingManager()
 
     static func keyHash(_ input: String) -> String {
-        guard let data = input.data(using: .utf8) else { return "" }
-        var hash = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
-        data.withUnsafeBytes {
-            _ = CC_SHA256($0.baseAddress, CC_LONG(data.count), &hash)
-        }
-        let key = hash.map { String(format: "%02x", $0) }.joined()
-        return String(key.prefix(5))
+        String(input.sha256HashString.prefix(5))
     }
 
     private var cacheDirectoryURL: URL

--- a/Sources/CommonMain/Caching/CachingManager.swift
+++ b/Sources/CommonMain/Caching/CachingManager.swift
@@ -15,7 +15,7 @@ public class CachingManager: CachingLayer {
     public static let shared = CachingManager()
 
     static func keyHash(_ input: String) -> String {
-        String(input.sha256HashString.prefix(5))
+        input.sha256HashString
     }
 
     private var cacheDirectoryURL: URL

--- a/Sources/CommonMain/Utils/String+Hash.swift
+++ b/Sources/CommonMain/Utils/String+Hash.swift
@@ -1,0 +1,35 @@
+//
+//  String+Hash.swift
+//  GrowthBook-IOS
+//
+//  Created by Vitalii Budnik on 3/5/25.
+//
+
+import CommonCrypto
+import CryptoKit
+
+extension String {
+    var sha256HashString: String {
+        guard let data = data(using: .utf8) else { return "" }
+
+        let hashBytes: [UInt8]
+
+        if #available(iOS 13.0, macOS 10.15, watchOS 6.0, tvOS 13.0, *) {
+            hashBytes = [UInt8](SHA256.hash(data: data))
+        } else {
+            var hashedBytes: [UInt8] = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
+            data.withUnsafeBytes {
+                _ = CC_SHA256($0.baseAddress, CC_LONG(data.count), &hashedBytes)
+            }
+            hashBytes = hashedBytes
+        }
+
+        return hashBytes.hexString
+    }
+}
+
+extension [UInt8] {
+    fileprivate var hexString: String {
+        map { String(format: "%02x", $0) }.joined()
+    }
+}


### PR DESCRIPTION
* || needs to be escaped in shell.
* Attribute name and attribute value can contain some characters not supported by FS.
 
Using hash instead of plain string.